### PR TITLE
[0.1.6] - 2025-02-20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
 
+## [0.1.6] - 2025-02-20
+### Fixed
+- pyproject.toml: Replaced "poetry.dev-dependencies" with
+  "poetry.group.dev.dependencies".
+- post_gen_project.py: Replaced "poetry shell" with eval $(poetry env activate)
+
+
 ## [0.1.5] - 2024-09-25
 ### Fixed
 - Somewhere along the line the file permissions got jacked up.  Removed

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -14,7 +14,7 @@ def print_instructions():
     print("")
     print("Run these commands to complete project creation:")
     print("1. cd {{ cookiecutter.project_name }}")
-    print("2. poetry shell")
+    print("2. eval $(poetry env activate)")
     print("3. poetry update")
     print("")
 

--- a/{{cookiecutter.project_directory}}/pyproject.toml
+++ b/{{cookiecutter.project_directory}}/pyproject.toml
@@ -9,7 +9,7 @@ python = "^{{ cookiecutter.python_version }}"
 aaron-common-libs = {git = "https://github.com/aaronmelton/aaron-common-libs.git"}
 {% if cookiecutter.use_rich_console == "yes" -%}rich = "^13.7.0"{%- endif %}
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 bandit = "^1.7.8"
 black = "^24.4.2"
 coverage = "^7.6.0"


### PR DESCRIPTION
## [0.1.6] - 2025-02-20
### Fixed
- pyproject.toml: Replaced "poetry.dev-dependencies" with
"poetry.group.dev.dependencies".
- post_gen_project.py: Replaced "poetry shell" with eval $(poetry env activate)
